### PR TITLE
Fix getting kind with HONTESS_NOT_FOUND

### DIFF
--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -275,9 +275,9 @@ memtier_policy_static_ratio_get_kind(struct memtier_memory *memory,
     size_t size_tier, size_0;
     int i;
     int dest_tier = 0;
-    memkind_atomic_get(g_alloc_size[cfg[0].kind->partition], size_0);
+    size_0 = memtier_kind_allocated_size(cfg[0].kind);
     for (i = 1; i < memory->cfg_size; ++i) {
-        memkind_atomic_get(g_alloc_size[cfg[i].kind->partition], size_tier);
+        size_tier = memtier_kind_allocated_size(cfg[i].kind);
         if ((size_tier * cfg[i].kind_ratio) < size_0) {
             dest_tier = i;
         }


### PR DESCRIPTION
In fallback to static ratio scenario when hotness equals
HOTNESS_NOT_FOUND, decision with which kind to allocate was made on
wrong data. This commit fixes this issue.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bratpiorka/memkind_hot_poc/19)
<!-- Reviewable:end -->
