### PR TITLE
Fix getting kind with HOTNESS_NOT_FOUND

### DIFF
--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -258,7 +258,7 @@ static inline void decrement_alloc_size(unsigned kind_id, size_t size)
     unsigned bucket_id = t_hash_64();
     long long old_talloc =
         memkind_atomic_decrement(t_alloc_size[kind_id][bucket_id], size);
-    if (old_talloc - size < -FLUSH_THRESHOLD)
+    if ((old_talloc - (long long)size) < -FLUSH_THRESHOLD)
         apply_temporary_buffer_alloc_size(kind_id, bucket_id);
 }
 

--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -1338,3 +1338,30 @@ TEST_F(MemkindMemtierThresholdTest, test_various_alloc_size)
         memtier_free(ptr);
     }
 }
+
+TEST_F(MemkindMemtierMemoryTest, test_static_ratio_with_free)
+{
+    size_t size = 1e6;
+    std::vector<void *> allocs_regular;
+
+    void *ptr_default = memtier_malloc(m_tier_memory, size);
+    ASSERT_NE(ptr_default, nullptr);
+    ASSERT_EQ(memkind_detect_kind(ptr_default), MEMKIND_DEFAULT);
+    for (int i = 0; i < MEMKIND_REGULAR_ratio; ++i) {
+        void *ptr_regular = memtier_malloc(m_tier_memory, size);
+        ASSERT_NE(ptr_regular, nullptr);
+        ASSERT_EQ(memkind_detect_kind(ptr_regular), MEMKIND_REGULAR);
+        allocs_regular.push_back(ptr_regular);
+    }
+
+    memtier_free(allocs_regular.back());
+    allocs_regular.pop_back();
+    void *ptr_regular = memtier_malloc(m_tier_memory, size);
+    ASSERT_NE(ptr_regular, nullptr);
+    ASSERT_EQ(memkind_detect_kind(ptr_regular), MEMKIND_REGULAR);
+    allocs_regular.push_back(ptr_regular);
+    
+    for (auto const &ptr : allocs_regular) {
+        memtier_free(ptr);
+    }
+}


### PR DESCRIPTION
In decrement_alloc_size, the FLUSH_THRESHOLD had been compared to a
value which was a result of a size_t overflow. As a result, with
FLUSH_THRESHOLD=0, the size was not updated.
This commit fixes that.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bratpiorka/memkind_hot_poc/22)
<!-- Reviewable:end -->
