### PR TITLE
Restrict ratio values in PI controller

### DIFF
--- a/src/ranking_controller.c
+++ b/src/ranking_controller.c
@@ -64,7 +64,13 @@ ranking_controller_calculate_fixed_thresh(ranking_controller *controller,
         e*controller->proportional
         + controller->integrated_error * controller->integral;
     double new_inv_thresh = a+ steering_signal;
+    
     double out = 1.0 - new_inv_thresh;
+    // restrict to values in a closed range <0,1>
+    if (out > 1.0)
+        out = 1.0;
+    else if (out < 0)
+        out = 0.0;
 
     return out;
 }


### PR DESCRIPTION
Limit ratio values in PI controller to the closed range <0,1>.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bratpiorka/memkind_hot_poc/25)
<!-- Reviewable:end -->
